### PR TITLE
save-query-on-refresh

### DIFF
--- a/src/components/editor/SQLEditor.tsx
+++ b/src/components/editor/SQLEditor.tsx
@@ -23,10 +23,30 @@ export default function SQLEditor({ queryTree, onQueryTreeChanged }: Props) {
 
     const TEXTAREA_ID = 'sql-editor-textarea';
 
+    const STORAGE_KEY = 'sqlEditorQuery'; 
+
     useEffect(() => {
-        updateQueryTree(code);
+
+        const saved = localStorage.getItem(STORAGE_KEY);
+
+        if (saved) {
+            setCode(saved);
+            updateQueryTree(saved);
+        }
+
+        else {
+            updateQueryTree('');
+        }
+
         focusTextArea();
+
     }, []);
+
+    useEffect(() => {
+
+        localStorage.setItem(STORAGE_KEY, code);
+
+    }, [code]);
 
     const focusTextArea = () => {
         const textAreaElement = document.getElementById(TEXTAREA_ID);


### PR DESCRIPTION
Added a feature to save what the user types in the SQL editor using localStorage. This way, when the user refreshes the page, the editor's content remains, and nothing the user was typing gets lost.