### PR TITLE
Fix/tarea1

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "start": "vite",
     "build": "vite build",
     "test": "jest",
-    "postinstall": "cp node_modules/web-tree-sitter/tree-sitter.wasm public"
+    "postinstall": "copy node_modules\\web-tree-sitter\\tree-sitter.wasm public"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
fix(visualizer): Corrige el renderizado de grafos para CTEs encadenadas

Se soluciona un bug que provocaba una visualización incorrecta en consultas con Expresiones Comunes de Tabla (CTEs) que dependen de otras CTEs definidas previamente. El grafo aparecía desconectado y con nodos duplicados.

La corrección se ha implementado en dos partes:

Parser (queryParser.ts): Se ha modificado el parser para que propague el contexto de las CTEs ya procesadas. Esto asegura que al analizar una CTE, se tenga conocimiento de las anteriores en la misma cláusula WITH.

Lógica del Grafo (useQueryFlow.ts): Se ha ajustado el hook que construye el grafo para que utilice el contexto completo de CTEs. De esta forma, distingue correctamente entre una referencia a otra CTE y una tabla externa, evitando así la creación de nodos erróneos y asegurando que las conexiones se dibujen correctamente.