### PR TITLE
Fix/tarea2

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "start": "vite",
     "build": "vite build",
     "test": "jest",
-    "postinstall": "cp node_modules/web-tree-sitter/tree-sitter.wasm public"
+    "postinstall": "copy node_modules\\web-tree-sitter\\tree-sitter.wasm public"
   },
   "eslintConfig": {
     "extends": [

--- a/src/hooks/useQueryFlow.ts
+++ b/src/hooks/useQueryFlow.ts
@@ -72,7 +72,8 @@ const flattenQueryTree = (node: Query, allCteQueries: Query[], parentHash?: stri
 
     
     const newReferences = node.fromClause.references.filter((ref) => {
-        return !allCteQueries.some(cte => cte.name === ref.name || cte.alias === ref.name);
+
+        return !allCteQueries.some(cte => cte.name === ref.name);
     });
 
     newReferences.forEach((reference) => {


### PR DESCRIPTION
El problema se manifestaba en consultas como:
WITH cte AS (SELECT a, b FROM c) SELECT a, c.b FROM cte c;

En este caso, la tabla c (dentro de la definición de la CTE) no se mostraba en el gráfico porque el alias de la CTE (c) entraba en conflicto con el nombre de la tabla.

Causa del error

La lógica para generar el grafo en src/hooks/useQueryFlow.ts filtraba las referencias de la cláusula FROM si su nombre coincidía con el name o el alias de cualquier CTE.

Solución implementada

Se ha modificado la lógica de filtrado para que las referencias a tablas solo se descarten si su name coincide con el name de una CTE, ignorando el alias. Esto previene la colisión de nombres y asegura que todas las tablas base se muestren correctamente en la visualización.

![image](https://github.com/user-attachments/assets/d68a189a-e77f-446f-a958-d970c26e616a)
