### PR TITLE
Fix cte bug

### DIFF
--- a/src/components/display/nodes/QueryNode.tsx
+++ b/src/components/display/nodes/QueryNode.tsx
@@ -53,7 +53,11 @@ export default function QueryNode({ data, resetHighlight }: Props) {
     const highlightEdges = (field: Field) => {
         setEdges((prevEdges) => {
             const updated = prevEdges.map((e) => {
-                const isFieldEdge = e.id.includes(field.id) || (field.references?.parentId && e.id.endsWith(field.references?.parentId));
+                const isFieldEdge = e.id.includes(field.id) || 
+                    field.references?.some(ref => 
+                        e.id.includes(ref.fieldId) || 
+                        e.id.includes(ref.nodeId)
+                    );
 
                 if (!isFieldEdge) {
                     return {


### PR DESCRIPTION
Fix: Corrección en la visualización de caminos en el grafo

Se ha corregido un problema en la visualización de los caminos en el grafo cuando se hace clic en campos con alias. El problema afectaba específicamente a la visualización de las referencias entre campos en CTEs y sus tablas base.


- Se mantiene la lógica original que permite:
  - Visualizar correctamente los caminos desde campos con alias hasta sus campos originales en CTEs
  - Mantener las referencias a las tablas base
  - Evitar referencias bidireccionales no deseadas
