### PR TITLE
feat: Añade menú de usuario en el header

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -8,13 +8,13 @@ import { useAppTheme } from "../theme/ThemeContext";
 import { useNavigate } from "react-router"; 
 import { UserContext } from "../contexts/UserContext";
 
-
 export default function Header() {
     const { t, i18n } = useTranslation();
     const [anchorElLang, setAnchorElLang] = useState<null | HTMLElement>(null);
+    const [anchorElUser, setAnchorElUser] = useState<null | HTMLElement>(null);
     const { mode, toggleTheme } = useAppTheme();
     const navigate = useNavigate(); 
-    const { user } = useContext(UserContext);
+    const { user, logout } = useContext(UserContext);
 
     const changeLanguage = (lng: string) => {
         i18n.changeLanguage(lng);
@@ -29,6 +29,26 @@ export default function Header() {
         if (lng) {
             changeLanguage(lng);
         }
+    };
+
+    // NUEVO: handlers para el menú de usuario
+    const handleUserMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
+        setAnchorElUser(event.currentTarget);
+    };
+
+    const handleUserMenuClose = () => {
+        setAnchorElUser(null);
+    };
+
+    const handleProfile = () => {
+        handleUserMenuClose();
+        navigate('/profile');
+    };
+
+    const handleLogout = () => {
+        handleUserMenuClose();
+        if (logout) logout();
+        navigate('/login');
     };
 
     return (
@@ -66,15 +86,26 @@ export default function Header() {
                     {mode === 'dark' ? <Brightness7Icon /> : <Brightness4Icon />}
                 </IconButton>
                 {user ? (                    
-                    <IconButton
-                        color="inherit"                        
-                        onClick={() => navigate('/profile')} 
-                        aria-label="account of current user"
-                        aria-controls="menu-appbar"
-                        aria-haspopup="true"
-                    >
-                        <AccountCircle />
-                    </IconButton>
+                    <>
+                        <IconButton
+                            color="inherit"
+                            onClick={handleUserMenuOpen}
+                            aria-label="account of current user"
+                            aria-controls="menu-user"
+                            aria-haspopup="true"
+                        >
+                            <AccountCircle />
+                        </IconButton>
+                        <Menu
+                            id="menu-user"
+                            anchorEl={anchorElUser}
+                            open={Boolean(anchorElUser)}
+                            onClose={handleUserMenuClose}
+                        >
+                            <MenuItem onClick={handleProfile}>{t('header.myProfile') ?? "Mi perfil"}</MenuItem>
+                            <MenuItem onClick={handleLogout}>{t('header.logout') ?? "Cerrar sesión"}</MenuItem>
+                        </Menu>
+                    </>
                 ) : (                    
                     <>
                         <Button color="inherit" onClick={() => navigate('/login')}>{t('header.login')}</Button>

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -6,6 +6,8 @@
     "goToEditor": "Go to Editor"
   },
   "header": {
+    "myProfile": "My Profile",
+    "logout": "Log Out",
     "appName": "VistaSQL",
     "login":"LogIn",
     "signUp":"signUp"

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -7,6 +7,8 @@
     "goToEditor": "Ir al Editor"
   },
   "header": {
+    "myProfile": "Mi perfil",
+    "logout": "Cerrar sesión",
     "appName": "VistaSQL",
     "login": "Iniciar Sesión",
     "signUp": "Registrarse"    


### PR DESCRIPTION
feat: Añade menú de usuario en el header

Se implementa un menú desplegable en el icono de usuario ([AccountCircle](vscode-file://vscode-app/c:/Users/zaton/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)) en el header.
El menú muestra las opciones:
Mi perfil (header.myProfile): Navega a la página de perfil del usuario.
Cerrar sesión (header.logout): Cierra la sesión y redirige a la pantalla de login.
El menú solo aparece cuando el usuario está autenticado; si no, se muestran los botones de "Iniciar sesión" y "Registrarse".
Se mantienen los controles de idioma y tema en el header.