### PR TITLE
Redirect logged-in users directly to the editor

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -51,6 +51,7 @@ export default function Header() {
         navigate('/login');
     };
 
+
     return (
         <AppBar component="nav" position="relative">
             <Toolbar>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,10 +1,14 @@
 import { Link } from "react-router";
+import { UserContext } from "../contexts/UserContext";
+import { useContext } from "react";
+
 
 export default function Home() {
+    
     return (
         <>
             <section className="flex flex-col items-center justify-center h-1/4 pt-4"> 
-                <Link to="/editor" className="bg-blue-500 rounded text-white px-4 py-2">
+                <Link to={"/editor"} className="bg-blue-500 rounded text-white px-4 py-2">
                     Ir a Editor
                 </Link>
             </section>

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -7,13 +7,14 @@ import { ApiService } from "../services/ApiService";
 import ErrorIcon from "@mui/icons-material/Error";
 import { Link, useNavigate } from 'react-router';
 import { UserContext } from "../contexts/UserContext";
+import { useEffect } from "react";
 
 export default function LoginPage() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [message, setMessage] = useState("");
   const [isLoading, setIsLoading] = useState(false);
-  const { login } = useContext(UserContext);
+  const { login, user} = useContext(UserContext);
   
   const { t } = useTranslation();
   const apiService = new ApiService();
@@ -34,6 +35,10 @@ export default function LoginPage() {
     login(token);
     navigate('/editor');
   };
+
+  useEffect(() => {
+    if (user) { navigate("/editor") }
+  }, [user,navigate])
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column' }}>      

--- a/src/pages/RegisterPage.tsx
+++ b/src/pages/RegisterPage.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next";
 import { ApiService } from "../services/ApiService";
 import { Link, useNavigate } from 'react-router';
 import { UserContext } from "../contexts/UserContext";
+import { useEffect } from "react";
 
 export default function RegisterPage() {
   const [email, setEmail] = useState("");
@@ -15,7 +16,7 @@ export default function RegisterPage() {
   
   const { t } = useTranslation();
   const navigate = useNavigate(); 
-  const { login } = useContext(UserContext);
+  const { login,user } = useContext(UserContext);
   const apiService = new ApiService();
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -33,6 +34,10 @@ export default function RegisterPage() {
     login(token);
     navigate('/editor');
   };
+
+  useEffect(() => {
+    if (user) { navigate("/editor") }    
+  }, [user,navigate])
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', flexBasis: 1 }}>


### PR DESCRIPTION
## Descripción de la PR
- Se añadió una función con 'useEffect' en los componentes de 'Login' y 'SignIn' para redirigir automáticamente al usuario a '/editor' si ya tiene sesión iniciada.
- Esto evita que un usuario con sesión activa acceda manualmente a las rutas '/login' o '/signin' escribiéndolas en la barra de navegación.
- La lógica se basa en la variable 'user' del 'UserContext'.

## Comportamiento del usuario
- Si el usuario no tiene sesión activa, aparecen ambos formularios sin problema.
- Si el usuario tiene sesión activa, se le redirige a "/editor" automáticamente.